### PR TITLE
Add left CMD mapping control

### DIFF
--- a/src/constants/left_cmd_off.reg
+++ b/src/constants/left_cmd_off.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Wine\Mac Driver]
+"LeftCommandIsCtrl"="n"
+

--- a/src/constants/left_cmd_on.reg
+++ b/src/constants/left_cmd_on.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Wine\Mac Driver]
+"LeftCommandIsCtrl"="y"
+

--- a/src/launcher/config/index.tsx
+++ b/src/launcher/config/index.tsx
@@ -28,6 +28,7 @@ import { createDxvkAsyncConfig } from "./dxvk-async";
 import { createDxvkHUDConfig } from "./dxvk-hud";
 import { createGameInstallDirConfig } from "./game-install-dir";
 import { createRetinaConfig } from "./retina";
+import { createLeftCmdConfig } from "./left-cmd";
 import { createWineDistroConfig } from "./wine-distribution";
 import { createWorkaround3Config } from "./workaround-3";
 import createLocaleConfig from "./ui-locale";
@@ -57,6 +58,7 @@ export async function createConfiguration({
   const [DA] = await createDxvkAsyncConfig({ locale, config });
   const [DH] = await createDxvkHUDConfig({ locale, config });
   const [R] = await createRetinaConfig({ locale, config });
+  const [LC] = await createLeftCmdConfig({ locale, config });
   const [GID] = await createGameInstallDirConfig({
     locale,
     config,
@@ -128,6 +130,7 @@ export async function createConfiguration({
                       <DA />
                       <DH />
                       <R />
+                      <LC />
                       <Divider />
                       <PO />
                       <W3 />

--- a/src/launcher/config/left-cmd.tsx
+++ b/src/launcher/config/left-cmd.tsx
@@ -1,0 +1,62 @@
+import { FormControl, FormLabel, Box, Checkbox } from "@hope-ui/solid";
+import { createEffect, createSignal } from "solid-js";
+import { Locale } from "../../locale";
+import { getKey, setKey } from "../../utils";
+import { Config, NOOP } from "./config-def";
+
+declare module "./config-def" {
+  interface Config {
+    leftCmd: boolean;
+  }
+}
+
+export async function createLeftCmdConfig({
+  locale,
+  config,
+}: {
+  config: Partial<Config>;
+  locale: Locale;
+}) {
+  try {
+    config.leftCmd = (await getKey("left_cmd")) == "true";
+  } catch {
+    config.leftCmd = false; // default value
+  }
+
+  const [value, setValue] = createSignal(config.leftCmd);
+
+  async function onSave(apply: boolean) {
+    if(!apply) {
+      setValue(config.leftCmd!);
+      return NOOP;
+    }
+    if (config.leftCmd! == value()) return NOOP;
+    config.leftCmd = value();
+    await setKey("left_cmd", config.leftCmd! ? "true" : "false");
+    return NOOP;
+  }
+  
+  createEffect(()=>{
+    value();
+    onSave(true);
+  });
+
+  return [
+    function UI() {
+      return (
+        <FormControl id="leftCmd">
+          <FormLabel>{locale.get("SETTING_LEFT_CMD")}</FormLabel>
+          <Box>
+            <Checkbox
+              checked={value()}
+              size="md"
+              onChange={() => setValue((x) => !x)}
+            >
+              {locale.get("SETTING_ENABLED")}
+            </Checkbox>
+          </Box>
+        </FormControl>
+      );
+    },
+  ] as const;
+}

--- a/src/launcher/program-launch-game.ts
+++ b/src/launcher/program-launch-game.ts
@@ -1,6 +1,8 @@
 import a from "../../external/bWh5cHJvdDJfcnVubmluZy5yZWcK.reg?url";
 import retina_on from "../constants/retina_on.reg?url";
 import retina_off from "../constants/retina_off.reg?url";
+import left_cmd_on from "../constants/left_cmd_on.reg?url";
+import left_cmd_off from "../constants/left_cmd_off.reg?url";
 
 import { join } from "path-browserify";
 import { CommonUpdateProgram } from "../common-update-ui";
@@ -42,6 +44,13 @@ export async function* launchGameProgram({
   } else {
     await putLocal(retina_off, await resolve("retina.reg"));
   }
+
+  if (config.leftCmd) {
+    await putLocal(left_cmd_on, await resolve("left_cmd.reg"));
+  } else {
+    await putLocal(left_cmd_off, await resolve("left_cmd.reg"));
+  }
+
   const cmd = `@echo off
 cd "%~dp0"
 regedit bWh5cHJvdDJfcnVubmluZy5yZWcK.reg
@@ -50,6 +59,7 @@ copy "${wine.toWinePath(
     join(gameDir, atob("SG9Zb0tQcm90ZWN0LnN5cw=="))
   )}" "%WINDIR%\\system32\\"
 regedit retina.reg
+regedit left_cmd.reg
 ${await (async () => {
   if (config.fpsUnlock !== "default") {
     return `"${wine.toWinePath(
@@ -118,6 +128,7 @@ ${await (async () => {
 
   await removeFile(await resolve("bWh5cHJvdDJfcnVubmluZy5yZWcK.reg"));
   await removeFile(await resolve("retina.reg"));
+  await removeFile(await resolve("left_cmd.reg"));
   await removeFile(await resolve("config.bat"));
   yield ["setStateText", "REVERT_PATCHING"];
   yield* patchRevertProgram(gameDir, wine.prefix, server, config);

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -57,6 +57,7 @@ export const en: typeof zh_CN = {
   SETTING_DXVK_HUD_FPS: "FPS only",
   SETTING_DXVK_HUD_ALL: "Everything",
   SETTING_RETINA: "Retina Mode",
+  SETTING_LEFT_CMD: "Map left CMD to CTRL",
   SETTING_SAVE: "Save",
   SETTING_CANCEL: "Cancel",
 

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -58,6 +58,7 @@ import { zh_CN } from "./zh_CN";
     SETTING_DXVK_HUD_FPS: "Solo FPS",
     SETTING_DXVK_HUD_ALL: "Todo",
     SETTING_RETINA: "Modo Retina",
+    SETTING_LEFT_CMD: "Asignar CMD izquierdo a CTRL",
     SETTING_SAVE: "Guardar",
     SETTING_CANCEL: "Cancelar",
   

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -58,6 +58,7 @@ export const ru_RU: typeof zh_CN = {
   SETTING_DXVK_HUD_FPS: "Только FPS",
   SETTING_DXVK_HUD_ALL: "Всё",
   SETTING_RETINA: "Режим Retina",
+  SETTING_LEFT_CMD: "Сопоставить левый CMD с CTRL",
   SETTING_SAVE: "Сохранить",
   SETTING_CANCEL: "Отменить",
 

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -58,6 +58,7 @@ export const vi_VN: typeof zh_CN = {
   SETTING_DXVK_HUD_FPS: "Chỉ hiện FPS",
   SETTING_DXVK_HUD_ALL: "Hiện tất cả thông tin",
   SETTING_RETINA: "Chế độ Retina",
+  SETTING_LEFT_CMD: "Ánh xạ CMD trái sang CTRL",
   SETTING_SAVE: "Lưu",
   SETTING_CANCEL: "Huỷ",
 

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -56,6 +56,7 @@ export const zh_CN = {
     SETTING_DXVK_HUD_FPS: "显示FPS",
     SETTING_DXVK_HUD_ALL: "显示所有信息",
     SETTING_RETINA: "Retina 模式",
+    SETTING_LEFT_CMD: "映射左 CMD 键为 CTRL 键",
     SETTING_SAVE: "保存",
     SETTING_CANCEL: "取消",
 


### PR DESCRIPTION
Left CMD was previously mapped to the left CTRL key. This could cause your character to accidentally switch between walk and run modes during gameplay, since the left CMD key is heavily used on macOS.

Now, the launcher has control over the key mapping of the left CMD key. By default, it is not mapped to the CTRL key.

Please note that you can still use the left CMD key for shortcuts in-game, such as left CMD + Tab to switch between your applications.

image1: [Wine documentation](https://wiki.winehq.org/MacOS_FAQ#How_come_my_keyboard_shortcuts_don.27t_work_like_normal)
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/26551884/231930197-812de13b-d650-40ff-b6e4-bd8c1064a0b3.png">

image2: Chinese launcher UI
<img width="999" alt="image" src="https://user-images.githubusercontent.com/26551884/231932311-f4f3cdce-534b-4af6-b21d-750fe6bee676.png">

image3: English launcher UI (Other languages were done by translators)
<img width="999" alt="image" src="https://user-images.githubusercontent.com/26551884/231932260-e575a2fc-46ad-4cc4-8cc6-ab37cb766137.png">
