### PR TITLE
feat: Update minimum system version to 10.15

### DIFF
--- a/build-app.js
+++ b/build-app.js
@@ -320,7 +320,7 @@ PATH_LAUNCH="$(dirname "$CONTENTS_DIR")" exec "$SCRIPT_DIR/${appname}" --path="$
         <key>NSHumanReadableCopyright</key>
         <string>Copyright © 2023 3Shain.</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.13.0</string>
+        <string>10.15.0</string>
         <key>NSAppTransportSecurity</key>
         <dict>
             <key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
This pull request updates the LSMinimumSystemVersion to 10.15.0 (macOS Catalina) for all builds.

While maintaining the Homebrew Cask for Yet Another Anime Game Launcher (YAAGL) in the [HuaDeity/homebrew-tap](https://github.com/HuaDeity/homebrew-tap)
 repository, I encountered issues caused by outdated macOS version settings:

- Fixes the deprecation warning for depends_on macos: :high_sierra reported in HuaDeity/homebrew-tap#66.
- Addresses the compatibility discussion in HuaDeity/homebrew-tap#33 by unifying the minimum system version.

This PR sets the baseline to macOS 10.15 (Catalina), following Crossover’s system requirement as a practical minimum.
Although the project’s Apple Silicon support suggests macOS 14 (Sonoma)—consistent with DXMT—as a more technically accurate target, raising the minimum version to that level may need further discussion to evaluate its impact on Intel users.

--- 

此 PR 将 LSMinimumSystemVersion 统一更新为 10.15.0（macOS Catalina）。

在维护 [HuaDeity/homebrew-tap](https://github.com/HuaDeity/homebrew-tap) 仓库中 Yet Another Anime Game Launcher (YAAGL) 的 Homebrew 安装方式时，遇到了旧版 macOS 版本声明导致的问题：

- 修复了 HuaDeity/homebrew-tap#66 中的 depends_on macos: :high_sierra 弃用警告。
- 解决了 HuaDeity/homebrew-tap#33 中关于系统版本兼容性的讨论，通过统一最低系统版本来保持一致性。

此次更新暂时将最低系统版本设为 macOS 10.15（Catalina），参考了 Crossover 的系统要求，作为当前较为稳妥的基线。
考虑到项目对 Apple Silicon 的支持，从技术角度看更合适的目标版本可能是 macOS 14 (Sonoma)（与 DXMT 保持一致），但提升至该要求可能影响 Intel 用户，因此仍需进一步讨论。