### PR TITLE
fix: fix sophon internal error 'str' object has no attribute 'joinpath' when verifying game files for GI CN version

### DIFF
--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -412,7 +412,7 @@ class SophonClient:
 			if gamedir("GenshinImpact.exe").is_file():
 				self.rel_type = "os"
 			elif gamedir("YuanShen.exe").is_file():
-				if self.gamedatadir.joinpath("Plugins", "PCGameSDK.dll").is_file():
+				if gamedir(self.gamedatadir, "Plugins", "PCGameSDK.dll").is_file():
 					self.rel_type = "bb"
 				else:
 					self.rel_type = "cn"


### PR DESCRIPTION
fixed #612