### PR TITLE
Fix HSR CN 4.3.0 version detection

### DIFF
--- a/src/clients/mhy/unity.ts
+++ b/src/clients/mhy/unity.ts
@@ -44,6 +44,9 @@ export async function getGameVersion2019(gameDataDir: string) {
     if (ggmMD5 == "3602065e153d9782a0f0cf4a73a98b44") {
       return "3.8.0";
     }
+    if (ggmMD5 == "01fbfd295247a36ef97109121bd3ec01") {
+      return "4.3.0";
+    }
     return "9.99.99";
   } else {
     for (let j = index; j < index + 0x80; j++) {


### PR DESCRIPTION
On HSR CN version 4.3, yaagl can not detect the unity version and display as 9.99.99. This bug blocks the launch of the game. (#686) The PR fixes this bug and it works on my mac.

This comment is helped by Claude Code 4.5, supervised by me.