### PR TITLE
Improve NAP Wine launch diagnostics and stabilize DXMT WINEMSYNC env

### DIFF
--- a/src/clients/mhy/nap/config/debug-launch.tsx
+++ b/src/clients/mhy/nap/config/debug-launch.tsx
@@ -1,0 +1,65 @@
+import { FormControl, FormLabel, Box, Checkbox } from "@hope-ui/solid";
+import { createEffect, createSignal } from "solid-js";
+import { Locale } from "@locale";
+import { assertValueDefined, getKey, setKey } from "@utils";
+import { Config, NOOP } from "@config/config-def";
+
+declare module "@config/config-def" {
+  interface Config {
+    debugLaunch: boolean;
+  }
+}
+
+const CONFIG_KEY = "config_debug_launch";
+
+export default async function ({
+  locale,
+  config,
+}: {
+  config: Partial<Config>;
+  locale: Locale;
+}) {
+  try {
+    config.debugLaunch = (await getKey(CONFIG_KEY)) == "true";
+  } catch {
+    config.debugLaunch = false;
+  }
+
+  const [value, setValue] = createSignal(config.debugLaunch);
+
+  async function onSave(apply: boolean) {
+    assertValueDefined(config.debugLaunch);
+    if (!apply) {
+      setValue(config.debugLaunch);
+      return NOOP;
+    }
+    if (config.debugLaunch == value()) return NOOP;
+    config.debugLaunch = value();
+    await setKey(CONFIG_KEY, config.debugLaunch ? "true" : "false");
+    return NOOP;
+  }
+
+  createEffect(() => {
+    value();
+    onSave(true);
+  });
+
+  return [
+    function UI() {
+      return (
+        <FormControl id="debugLaunch">
+          <FormLabel>{locale.get("SETTING_DEBUG_LAUNCH")}</FormLabel>
+          <Box>
+            <Checkbox
+              checked={value()}
+              onChange={() => setValue(x => !x)}
+              size="md"
+            >
+              {locale.get("SETTING_ENABLED")}
+            </Checkbox>
+          </Box>
+        </FormControl>
+      );
+    },
+  ] as const;
+}

--- a/src/clients/mhy/nap/index.tsx
+++ b/src/clients/mhy/nap/index.tsx
@@ -40,6 +40,7 @@ import createResolution from "./config/resolution";
 import createBlockNet from "./config/block-net";
 import createSteamPatch from "./config/steam-patch";
 import createTimeoutFix from "./config/timeout-fix";
+import createDebugLaunch from "./config/debug-launch";
 import { getGameVersion as _getGameVersion } from "../unity";
 import {
   HoyoConnectGameBackgroundType,
@@ -365,6 +366,7 @@ export async function createNAPChannelClient({
       const [BN] = await createBlockNet({ locale, config });
       const [SP] = await createSteamPatch({ locale, config });
       const [TF] = await createTimeoutFix({ locale, config });
+      const [DL] = await createDebugLaunch({ locale, config });
 
       return function () {
         return [
@@ -375,6 +377,7 @@ export async function createNAPChannelClient({
           <BN />,
           <SP />,
           <TF />,
+          <DL />,
         ];
       };
     },

--- a/src/clients/mhy/nap/program-launch-game.ts
+++ b/src/clients/mhy/nap/program-launch-game.ts
@@ -2,22 +2,40 @@ import { join } from "path-browserify";
 import { CommonUpdateProgram } from "../../../common-update-ui";
 import { Server } from "../../../constants";
 import {
+  alert,
+  appendFile,
+  env as getEnv,
+  fileOrDirExists,
   mkdirp,
   removeFile,
+  readFile,
   writeBinary,
   writeFile,
   readBinary,
+  readDirectory,
   resolve,
   utf16le,
   log,
   exec,
   getKeyOrDefault,
+  summarizeText,
+  findBlockedHostsEntries,
 } from "../../../utils";
-import { Wine } from "../../../wine";
+import { DEBUG_WINEDEBUG, Wine } from "../../../wine";
 import { Config } from "@config";
-import { putLocal, patchProgram, patchRevertProgram } from "../patch";
+import { patchProgram, patchRevertProgram } from "../patch";
 import { NAP_CN_BLOCK_URL, NAP_OS_BLOCK_URL } from "../../secret";
-import { gt } from "semver";
+
+interface LaunchDiagnostics {
+  debug: boolean;
+  id: number;
+  metaLog: string;
+  fixWebviewLog: string;
+  setPropsLog: string;
+  patchLog: string;
+  blockNetLog: string;
+  gameLog: string;
+}
 
 export async function* launchGameProgram({
   gameDir,
@@ -34,9 +52,56 @@ export async function* launchGameProgram({
 }): CommonUpdateProgram {
   yield ["setUndeterminedProgress"];
   yield ["setStateText", "PATCHING"];
+  await mkdirp(resolve("./logs"));
 
-  await fixWebview(wine, server);
-  await wine.setProps(config);
+  const launchId = Date.now();
+  const launchMode = config.steamPatch ? "steam-patch" : "config-bat";
+  const diagnostics = createLaunchDiagnostics(launchId, launchMode, config);
+  const yaaglDir = resolve("./");
+  const dxmtConfigFile = join(yaaglDir, "dxmt.conf");
+  await recordLaunchDiagnostic(
+    diagnostics.metaLog,
+    [
+      `launchId=${launchId}`,
+      `launchMode=${launchMode}`,
+      `server=${server.id}`,
+      `gameDir=${gameDir}`,
+      `gameExecutable=${gameExecutable}`,
+      `winePrefix=${wine.prefix}`,
+      `renderBackend=${wine.attributes.renderBackend ?? "unknown"}`,
+      `wineTag=${await getKeyOrDefault("wine_tag", "unknown")}`,
+      `dxmtVersion=${await getKeyOrDefault(
+        "installed_dxmt_version",
+        "unknown"
+      )}`,
+      `dxmtConfigFile=${dxmtConfigFile}`,
+      `dxmtConfigFileExists=${await fileOrDirExists(dxmtConfigFile)}`,
+      `steamPatch=${config.steamPatch}`,
+      `timeoutFix=${config.timeoutFix}`,
+      `patchOff=${config.patchOff}`,
+      `blockNet=${config.blockNet}`,
+      `proxyEnabled=${config.proxyEnabled}`,
+      `proxyHost=${config.proxyHost}`,
+      `proxyNote=proxy is recorded only; this diagnostic path does not treat proxy settings as a primary failure cause`,
+      `debugLaunch=${config.debugLaunch}`,
+    ].join("\n")
+  );
+
+  await wine.prepareForLaunch(
+    diagnostics.debug
+      ? {
+          phase: "nap.prepareWineServer",
+          logFile: diagnostics.metaLog,
+          teeOutput: true,
+          debug: true,
+        }
+      : undefined
+  );
+  await fixWebview(wine, server, diagnostics);
+  await wine.setProps(config, {
+    debug: diagnostics.debug,
+    logFile: diagnostics.setPropsLog,
+  });
 
   const args = [];
   if (config.resolutionCustom) {
@@ -52,12 +117,18 @@ copy "${wine.toWinePath(
 cd /d "${wine.toWinePath(gameDir)}"
 "${wine.toWinePath(join(gameDir, gameExecutable))}" ${args.join(" ")}`;
   await writeFile(resolve("config.bat"), cmd);
+  await recordLaunchDiagnostic(
+    diagnostics.metaLog,
+    [`configBatPath=${resolve("config.bat")}`, "configBat:", cmd].join("\n")
+  );
+  await recordLaunchDiagnostic(diagnostics.patchLog, "patchProgram start");
   yield* patchProgram(gameDir, wine, server, config);
-  await mkdirp(resolve("./logs"));
-  const yaaglDir = resolve("./");
+  await recordLaunchDiagnostic(diagnostics.patchLog, "patchProgram end");
+  let launchErrorSummary: string | undefined;
+  let launchStartedAt = new Date();
   try {
     yield ["setStateText", "GAME_RUNNING"];
-    const logfile = resolve(`./logs/game_${Date.now()}.log`);
+    launchStartedAt = new Date();
 
     if (config.blockNet) {
       const tmpScriptPath = "/tmp/yaagl_network_block_script.sh";
@@ -89,7 +160,14 @@ cd /d "${wine.toWinePath(gameDir)}"
           `do shell script "source ${tmpScriptPath} > /dev/null 2>&1 &" with administrator privileges`,
         ],
         {},
-        false
+        diagnostics.debug
+          ? {
+              phase: "nap.blockNet",
+              logFile: diagnostics.blockNetLog,
+              teeOutput: true,
+              debug: true,
+            }
+          : false
       );
     }
 
@@ -101,12 +179,12 @@ cd /d "${wine.toWinePath(gameDir)}"
       {
         MTL_HUD_ENABLED: config.metalHud ? "1" : "",
         WINEDLLOVERRIDES: "",
+        ...(diagnostics.debug ? { WINEDEBUG: DEBUG_WINEDEBUG } : {}),
         WINE_ENABLE_TIMEOUT_FIX: config.timeoutFix ? "1" : "0",
         ...(wine.attributes.renderBackend == "dxmt"
           ? {
-              WINEMSYNC: "1",
               DXMT_LOG_PATH: yaaglDir,
-              DXMT_CONFIG_FILE: join(yaaglDir, "dxmt.conf"),
+              DXMT_CONFIG_FILE: dxmtConfigFile,
               GST_PLUGIN_FEATURE_RANK: "atdec:MAX,avdec_h264:MAX",
             }
           : {
@@ -119,24 +197,59 @@ cd /d "${wine.toWinePath(gameDir)}"
             }
           : {}),
       },
-      logfile
+      {
+        phase: `nap.launch.${launchMode}`,
+        logFile: diagnostics.gameLog,
+        debug: diagnostics.debug,
+      }
     );
     await wine.waitUntilServerOff();
     if (config.resolutionCustom) {
       await revertResolutionRegistry(wine, server);
     }
   } catch (e: unknown) {
-    // it seems game crashed?
-    await log(String(e));
+    const crashReports = await collectCrashReports(launchStartedAt);
+    const driverErrorLog = join(gameDir, "driverError.log");
+    const driverError = await readTextIfExists(driverErrorLog);
+    const gameLog = await readTextIfExists(diagnostics.gameLog);
+    const blockedHosts = await collectBlockedHosts(server);
+    const diagnosticHints = buildDiagnosticHints({
+      config,
+      blockedHosts,
+      driverError,
+      gameLog,
+    });
+    launchErrorSummary = buildLaunchFailureSummary({
+      error: e,
+      launchMode,
+      diagnostics,
+      crashReports,
+      blockedHosts,
+      driverErrorLog,
+      driverError,
+      diagnosticHints,
+    });
+    await log(launchErrorSummary);
+    await recordLaunchDiagnostic(diagnostics.metaLog, launchErrorSummary);
   }
 
   // await removeFile(resolve("bWh5cHJvdDJfcnVubmluZy5yZWcK.reg"));
   await removeFile(resolve("config.bat"));
   yield ["setStateText", "REVERT_PATCHING"];
   yield* patchRevertProgram(gameDir, wine, server, config);
+  if (launchErrorSummary) {
+    await alert(
+      "Game launch failed",
+      buildLaunchFailureAlert(launchMode, diagnostics)
+    );
+  }
 }
 
-async function fixWebview(wine: Wine, server: Server) {
+async function fixWebview(
+  wine: Wine,
+  server: Server,
+  diagnostics: LaunchDiagnostics
+) {
   let key = "HKEY_CURRENT_USER\\Software\\\x6d\x69\x48\x6f\x59\x6f\\";
   if (server.id === "nap_cn") {
     key += "\u7edd\u533a\u96f6";
@@ -154,11 +267,29 @@ async function fixWebview(wine: Wine, server: Server) {
   ];
 
   try {
-    await wine.exec("reg", ["query", key], {}, resolve("fix_webview.log"));
+    await wine.exec(
+      "reg",
+      ["query", key],
+      diagnostics.debug ? { WINEDEBUG: DEBUG_WINEDEBUG } : {},
+      diagnostics.debug
+        ? {
+            phase: "nap.fixWebview.reg-query",
+            logFile: diagnostics.fixWebviewLog,
+            teeOutput: true,
+            debug: true,
+          }
+        : resolve("fix_webview.log")
+    );
 
     // the output contains malformed CJK characters
     const decoder = new TextDecoder("utf-8", { fatal: false });
-    const output = decoder.decode(await readBinary(resolve("fix_webview.log")));
+    const output = decoder.decode(
+      await readBinary(
+        diagnostics.debug
+          ? diagnostics.fixWebviewLog
+          : resolve("fix_webview.log")
+      )
+    );
 
     for (let line of output.split("\n")) {
       line = line.trim();
@@ -168,6 +299,10 @@ async function fixWebview(wine: Wine, server: Server) {
       }
     }
   } catch (e: unknown) {
+    await recordLaunchDiagnostic(
+      diagnostics.fixWebviewLog,
+      `fixWebview skipped after registry query failure:\n${String(e)}`
+    );
     return;
   }
 
@@ -175,8 +310,15 @@ async function fixWebview(wine: Wine, server: Server) {
   await wine.exec(
     "reg",
     ["import", `${wine.toWinePath(resolve("./fix_webview.reg"))}`],
-    {},
-    "/dev/null"
+    diagnostics.debug ? { WINEDEBUG: DEBUG_WINEDEBUG } : {},
+    diagnostics.debug
+      ? {
+          phase: "nap.fixWebview.reg-import",
+          logFile: diagnostics.fixWebviewLog,
+          teeOutput: true,
+          debug: true,
+        }
+      : "/dev/null"
   );
 }
 
@@ -225,4 +367,223 @@ async function revertResolutionRegistry(wine: Wine, server: Server) {
   } catch {
     return;
   }
+}
+
+function createLaunchDiagnostics(
+  id: number,
+  launchMode: string,
+  config: Config
+): LaunchDiagnostics {
+  const debug = config.debugLaunch;
+  const prefix = resolve(`./logs/launch_${id}`);
+  return {
+    debug,
+    id,
+    metaLog: `${prefix}_meta.log`,
+    fixWebviewLog: `${prefix}_fix-webview.log`,
+    setPropsLog: `${prefix}_set-props.log`,
+    patchLog: `${prefix}_patch.log`,
+    blockNetLog: `${prefix}_block-net.log`,
+    gameLog: debug
+      ? `${prefix}_game-${launchMode == "steam-patch" ? "steam" : "config"}.log`
+      : resolve(`./logs/game_${id}.log`),
+  };
+}
+
+async function recordLaunchDiagnostic(path: string, message: string) {
+  await appendFile(path, `${message}\n\n`);
+}
+
+async function readTextIfExists(path: string) {
+  try {
+    if (!(await fileOrDirExists(path))) return undefined;
+    return await readFile(path);
+  } catch {
+    return undefined;
+  }
+}
+
+async function collectCrashReports(since: Date) {
+  const home = await getEnv("HOME");
+  const until = new Date();
+  const reportDirs = [
+    join(home, "Library/Logs/DiagnosticReports"),
+    join(home, "Library/Logs/DiagnosticReports/Retired"),
+  ];
+  const namePatterns = [
+    "wine-preloader",
+    "wine",
+    "Rosetta",
+    "rosetta",
+    "Yaagl",
+    "yaagl",
+  ];
+  const reports: string[] = [];
+  for (const dir of reportDirs) {
+    let entries: Neutralino.filesystem.DirectoryEntry[] = [];
+    try {
+      entries = await readDirectory(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.type != "FILE") continue;
+      if (!isCrashReportInWindow(entry.entry, since, until)) continue;
+      if (!namePatterns.some(pattern => entry.entry.includes(pattern))) {
+        continue;
+      }
+      reports.push(join(dir, entry.entry));
+    }
+  }
+  return reports;
+}
+
+async function collectBlockedHosts(server: Server) {
+  const hosts = await readTextIfExists("/etc/hosts");
+  if (!hosts) return [];
+  return findBlockedHostsEntries(hosts, getKnownNapBlockDomains(server));
+}
+
+function getKnownNapBlockDomains(server: Server) {
+  return Array.from(
+    new Set([
+      server.id == "nap_cn" ? NAP_CN_BLOCK_URL : NAP_OS_BLOCK_URL,
+      NAP_CN_BLOCK_URL,
+      NAP_OS_BLOCK_URL,
+      "globaldp-prod-cn01.juequling.com",
+      "globaldp-prod-cn02.juequling.com",
+      "globaldp-prod-os01.zenlesszonezero.com",
+    ])
+  );
+}
+
+function isCrashReportInWindow(name: string, since: Date, until: Date) {
+  const parsedAt = parseCrashReportTime(name);
+  if (!parsedAt) return name.includes(formatCrashReportDay(since));
+  const lowerBound = since.getTime() - 60_000;
+  const upperBound = until.getTime() + 60_000;
+  return parsedAt.getTime() >= lowerBound && parsedAt.getTime() <= upperBound;
+}
+
+function parseCrashReportTime(name: string) {
+  const match = name.match(/-(\d{4})-(\d{2})-(\d{2})-(\d{6})/);
+  if (!match) return undefined;
+  const [, year, month, day, time] = match;
+  const hour = time.slice(0, 2);
+  const minute = time.slice(2, 4);
+  const second = time.slice(4, 6);
+  return new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  );
+}
+
+function formatCrashReportDay(date: Date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function buildLaunchFailureSummary({
+  error,
+  launchMode,
+  diagnostics,
+  crashReports,
+  blockedHosts,
+  driverErrorLog,
+  driverError,
+  diagnosticHints,
+}: {
+  error: unknown;
+  launchMode: string;
+  diagnostics: LaunchDiagnostics;
+  crashReports: string[];
+  blockedHosts: string[];
+  driverErrorLog: string;
+  driverError?: string;
+  diagnosticHints: string[];
+}) {
+  const message = error instanceof Error ? error.message : String(error);
+  return [
+    "Yaagl launch failed after Wine/DXMT launch command returned.",
+    `launchId=${diagnostics.id}`,
+    `launchMode=${launchMode}`,
+    `debugLaunch=${diagnostics.debug}`,
+    `gameLog=${diagnostics.gameLog}`,
+    `metaLog=${diagnostics.metaLog}`,
+    `fixWebviewLog=${diagnostics.fixWebviewLog}`,
+    `setPropsLog=${diagnostics.setPropsLog}`,
+    `patchLog=${diagnostics.patchLog}`,
+    crashReports.length
+      ? `matchingCrashReports:\n${crashReports.join("\n")}`
+      : "matchingCrashReports=none-found",
+    blockedHosts.length
+      ? `blockedHosts:\n${blockedHosts.join("\n")}`
+      : "blockedHosts=none-found",
+    driverError ? `driverErrorLog=${driverErrorLog}` : undefined,
+    driverError ? `driverError:\n${summarizeText(driverError)}` : undefined,
+    diagnosticHints.length
+      ? `diagnosticHints:\n${diagnosticHints.join("\n")}`
+      : undefined,
+    "error:",
+    summarizeText(message),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function buildDiagnosticHints({
+  config,
+  blockedHosts,
+  driverError,
+  gameLog,
+}: {
+  config: Config;
+  blockedHosts: string[];
+  driverError?: string;
+  gameLog?: string;
+}) {
+  const hints: string[] = [];
+  const combined = `${driverError ?? ""}\n${gameLog ?? ""}`;
+  if (blockedHosts.length) {
+    hints.push(
+      "hosts-block-detected: /etc/hosts blocks a known ZZZ launch domain"
+    );
+  }
+  if (
+    combined.includes("WDFLDR.SYS") ||
+    combined.includes("HoYoKProtect.sys") ||
+    combined.includes("initDriver Failed")
+  ) {
+    hints.push(
+      "game-driver-load-failure: game log shows HoYoKProtect/WDFLDR driver initialization failure"
+    );
+  }
+  if (config.patchOff) {
+    hints.push("patch-off-enabled: Yaagl game patch stage is disabled");
+  }
+  if (config.proxyEnabled) {
+    hints.push(
+      "proxy-enabled: proxy settings are recorded but not treated as a primary cause"
+    );
+  }
+  return hints;
+}
+
+function buildLaunchFailureAlert(
+  launchMode: string,
+  diagnostics: LaunchDiagnostics
+) {
+  return [
+    "Yaagl launch failed.",
+    `phase=nap.launch.${launchMode}`,
+    `launchId=${diagnostics.id}`,
+    `gameLog=${diagnostics.gameLog}`,
+    `metaLog=${diagnostics.metaLog}`,
+  ].join("\n");
 }

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -121,6 +121,8 @@ export const de_DE: typeof zh_CN = {
   SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
 
   UPDATE_PROMPT_IGNORE: "Update ignorieren",

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -119,6 +119,8 @@ export const en: typeof zh_CN = {
   SETTING_PROXY_DESC:
     "The proxy only applies to the game, not to the whole launcher.",
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: "Enable Steam Patch",
 
   UPDATE_PROMPT_IGNORE: "Ignore Update",

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -119,6 +119,8 @@ export const es_ES: typeof zh_CN = {
   SETTING_PROXY_DESC:
     "El proxy solo se aplica al juego, y no al launcher entero",
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: "Activar Parche de Steam",
 
   UPDATE_PROMPT_IGNORE: "Ignorar actualización",

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -123,6 +123,8 @@ export const fr_FR: typeof zh_CN = {
   SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
 
   UPDATE_PROMPT_IGNORE: "Ignorer la mise à jour",

--- a/src/locale/ja_JP.ts
+++ b/src/locale/ja_JP.ts
@@ -120,6 +120,8 @@ export const ja_JP: typeof zh_CN = {
   SETTING_PROXY_DESC:
     "このプロキシ設定はゲームのみに適用され、ランチャー全体には適用されません。",
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: "Steamパッチ有効",
 
   UPDATE_PROMPT_IGNORE: "更新無視",

--- a/src/locale/ko_KR.ts
+++ b/src/locale/ko_KR.ts
@@ -119,6 +119,8 @@ export const ko_KR: typeof zh_CN = {
   SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
 
   UPDATE_PROMPT_IGNORE: "업데이트 무시",

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -120,6 +120,8 @@ export const ru_RU: typeof zh_CN = {
   SETTING_PROXY_HOST: "Хост HTTP-прокси",
   SETTING_PROXY_DESC: "Прокси действует только на игру, а не на весь лаунчер.",
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: "Использовать патч Steam",
 
   UPDATE_PROMPT_IGNORE: "Пропустить обновление",

--- a/src/locale/th_TH.ts
+++ b/src/locale/th_TH.ts
@@ -117,6 +117,8 @@ export const th_TH: typeof zh_CN = {
   SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
 
   UPDATE_PROMPT_IGNORE: "ละเว้นการอัปเดต",

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -119,6 +119,8 @@ export const vi_VN: typeof zh_CN = {
   SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
+  SETTING_DEBUG_LAUNCH: "Debug Launch Logging",
+
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
 
   UPDATE_PROMPT_IGNORE: "Bỏ qua cập nhật",

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -114,6 +114,8 @@ export const zh_CN = {
   SETTING_PROXY_DESC:
     "The proxy only applies to the game, not to the whole launcher.", // TODO: Translate
 
+  SETTING_DEBUG_LAUNCH: "启动诊断日志",
+
   SETTING_TURN_ON_STEAM_PATCH: "Enable Steam Patch", // TODO: Translate
 
   UPDATE_PROMPT_IGNORE: "忽略此更新",

--- a/src/utils/hosts.spec.ts
+++ b/src/utils/hosts.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { findBlockedHostsEntries } from "./hosts";
+
+describe("hosts diagnostics", () => {
+  it("finds active hosts entries that block known launch domains", () => {
+    expect(
+      findBlockedHostsEntries(
+        [
+          "127.0.0.1 localhost",
+          "# 0.0.0.0 globaldp-prod-cn01.juequling.com",
+          "0.0.0.0 globaldp-prod-cn01.juequling.com",
+          "127.0.0.1 globaldp-prod-os01.zenlesszonezero.com",
+          "0.0.0.0 log-upload.mihoyo.com",
+        ].join("\n"),
+        [
+          "globaldp-prod-cn01.juequling.com",
+          "globaldp-prod-os01.zenlesszonezero.com",
+        ]
+      )
+    ).toEqual([
+      "0.0.0.0 globaldp-prod-cn01.juequling.com",
+      "127.0.0.1 globaldp-prod-os01.zenlesszonezero.com",
+    ]);
+  });
+
+  it("ignores comments, unrelated domains, and non-blocking hosts", () => {
+    expect(
+      findBlockedHostsEntries(
+        [
+          "# 0.0.0.0 globaldp-prod-cn01.juequling.com",
+          "192.168.1.2 globaldp-prod-cn01.juequling.com",
+          "0.0.0.0 log-upload.mihoyo.com",
+        ].join("\n"),
+        ["globaldp-prod-cn01.juequling.com"]
+      )
+    ).toEqual([]);
+  });
+});

--- a/src/utils/hosts.ts
+++ b/src/utils/hosts.ts
@@ -1,0 +1,25 @@
+const BLOCKING_HOSTS = new Set(["0.0.0.0", "127.0.0.1", "::1"]);
+
+export function findBlockedHostsEntries(
+  hostsText: string,
+  blockedDomains: string[]
+) {
+  const domains = new Set(
+    blockedDomains.map(domain => domain.toLowerCase()).filter(Boolean)
+  );
+  if (!domains.size) return [];
+
+  const matches: string[] = [];
+  for (const rawLine of hostsText.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const [address, ...hosts] = line.split(/\s+/);
+    if (!BLOCKING_HOSTS.has(address.toLowerCase())) continue;
+    if (hosts.some(host => domains.has(host.toLowerCase()))) {
+      matches.push(rawLine);
+    }
+  }
+
+  return matches;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./neu";
 export * from "./helper";
 export * from "./unix";
 export * from "./command-builder";
+export * from "./hosts";

--- a/src/utils/neu.spec.ts
+++ b/src/utils/neu.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildExecCommand, formatExecFailure } from "./neu";
+
+describe("exec diagnostics", () => {
+  it("redirects to log file unless teeOutput is enabled", () => {
+    expect(
+      buildExecCommand(["echo", "hello"], {}, { logFile: "/tmp/yaagl.log" })
+    ).toBe("echo hello &> /tmp/yaagl.log");
+
+    expect(
+      buildExecCommand(
+        ["echo", "hello"],
+        {},
+        { logFile: "/tmp/yaagl.log", teeOutput: true }
+      )
+    ).toBe("echo hello");
+  });
+
+  it("includes phase and log file in failure details", () => {
+    const message = formatExecFailure({
+      pid: 123,
+      exitCode: 5,
+      stdOut: "",
+      stdErr: "boom",
+      command: "wine game.exe",
+      phase: "nap.launch.steam-patch",
+      logFile: "/tmp/game.log",
+      cwd: "/Users/example/Library/Application Support/Yaagl ZZZ",
+      envDiff: "{ WINEPREFIX=/tmp/prefix, WINEMSYNC=1 }",
+      startedAt: "2026-07-04T06:00:00.000Z",
+      endedAt: "2026-07-04T06:00:01.000Z",
+    });
+
+    expect(message).toContain("Command return non-zero code (5)");
+    expect(message).toContain("Phase: nap.launch.steam-patch");
+    expect(message).toContain("LogFile: /tmp/game.log");
+    expect(message).toContain(
+      "Cwd: /Users/example/Library/Application Support/Yaagl ZZZ"
+    );
+    expect(message).toContain(
+      "EnvDiff: { WINEPREFIX=/tmp/prefix, WINEMSYNC=1 }"
+    );
+    expect(message).toContain("StdErr:\nboom");
+  });
+});

--- a/src/utils/neu.ts
+++ b/src/utils/neu.ts
@@ -1,6 +1,29 @@
 import { join } from "path-browserify";
 import { build, CommandSegments, rawString } from "./command-builder";
 
+export interface ExecOptions {
+  phase?: string;
+  logFile?: string;
+  teeOutput?: boolean;
+  debug?: boolean;
+  allowFailure?: boolean;
+}
+
+export interface ExecResultDetails extends Neutralino.os.ExecCommandResult {
+  command: string;
+  phase?: string;
+  logFile?: string;
+  cwd: string;
+  envDiff: string;
+  startedAt: string;
+  endedAt: string;
+}
+
+type ExecOptionsInput = boolean | ExecOptions | undefined;
+type LogRedirectInput = string | ExecOptions | undefined;
+
+const STDIO_SUMMARY_LIMIT = 4000;
+
 export function resolve(path: string): string {
   if (!path.startsWith("/")) {
     path = join(
@@ -19,58 +42,120 @@ export function resolve(path: string): string {
 export async function exec(
   segments: CommandSegments,
   env?: { [key: string]: string },
-  sudo = false,
-  log_redirect: string | undefined = undefined
-): Promise<Neutralino.os.ExecCommandResult> {
-  const cmd = build(
-    [...segments, ...(log_redirect ? [rawString("&>"), log_redirect] : [])],
-    env
+  sudoOrOptions: ExecOptionsInput = false,
+  logRedirectOrOptions: LogRedirectInput = undefined
+): Promise<ExecResultDetails> {
+  const { sudo, options } = normalizeExecOptions(
+    sudoOrOptions,
+    logRedirectOrOptions
   );
+  const cmd = buildExecCommand(segments, env, options);
+  const startedAt = new Date().toISOString();
+  const cwd = getExecutionCwd();
+  const envDiff = formatEnvDiff(env);
   await log(sudo ? runInSudo(cmd) : cmd);
+  await writeExecTrace(options, {
+    status: "start",
+    command: cmd,
+    cwd,
+    envDiff,
+    startedAt,
+  });
   const ret = await Neutralino.os.execCommand(sudo ? runInSudo(cmd) : cmd, {});
+  const endedAt = new Date().toISOString();
+  const detailedRet: ExecResultDetails = {
+    ...ret,
+    command: cmd,
+    phase: options.phase,
+    logFile: options.logFile,
+    cwd,
+    envDiff,
+    startedAt,
+    endedAt,
+  };
+  await writeExecTrace(options, {
+    status: "end",
+    command: cmd,
+    cwd,
+    envDiff,
+    startedAt,
+    endedAt,
+    exitCode: ret.exitCode,
+    stdOut: ret.stdOut,
+    stdErr: ret.stdErr,
+  });
   if (ret.exitCode != 0) {
-    throw new Error(
-      `Command return non-zero code (${ret.exitCode}) \n${cmd}\nStdOut:\n${ret.stdOut}\nStdErr:\n${ret.stdErr}`
-    );
+    if (options.allowFailure) return detailedRet;
+    throw new Error(formatExecFailure(detailedRet));
   }
-  return ret;
+  return detailedRet;
 }
 
 export async function exec2(
   segments: CommandSegments,
   env?: { [key: string]: string },
-  sudo = false,
-  log_redirect: string | undefined = undefined
-): Promise<Neutralino.os.ExecCommandResult> {
-  const cmd = build(
-    [...segments, ...(log_redirect ? [rawString("&>"), log_redirect] : [])],
-    env
+  sudoOrOptions: ExecOptionsInput = false,
+  logRedirectOrOptions: LogRedirectInput = undefined
+): Promise<ExecResultDetails> {
+  const { sudo, options } = normalizeExecOptions(
+    sudoOrOptions,
+    logRedirectOrOptions
   );
-  await log(cmd);
-  const { id, pid } = await Neutralino.os.spawnProcess(cmd);
+  const cmd = buildExecCommand(segments, env, options);
+  const startedAt = new Date().toISOString();
+  const cwd = getExecutionCwd();
+  const envDiff = formatEnvDiff(env);
+  await log(sudo ? runInSudo(cmd) : cmd);
+  await writeExecTrace(options, {
+    status: "start",
+    command: cmd,
+    cwd,
+    envDiff,
+    startedAt,
+  });
+  const { id, pid } = await Neutralino.os.spawnProcess(
+    sudo ? runInSudo(cmd) : cmd
+  );
   return await new Promise((res, rej) => {
+    let stdErr = "",
+      stdOut = "";
     const handler: Neutralino.events.Handler<
       Neutralino.os.SpawnProcessResult
-    > = event => {
+    > = async event => {
       if (!event) return;
-      let stdErr = "",
-        stdOut = "";
       if (event.detail.id == id) {
         if (event.detail["action"] == "exit") {
           const exit = Number(event.detail["data"]);
-          if (exit == 0) {
-            res({
-              pid,
-              exitCode: exit,
-              stdErr,
-              stdOut,
-            });
+          const endedAt = new Date().toISOString();
+          const detailedRet: ExecResultDetails = {
+            pid,
+            exitCode: exit,
+            stdErr,
+            stdOut,
+            command: cmd,
+            phase: options.phase,
+            logFile: options.logFile,
+            cwd,
+            envDiff,
+            startedAt,
+            endedAt,
+          };
+          await writeExecTrace(options, {
+            status: "end",
+            command: cmd,
+            cwd,
+            envDiff,
+            startedAt,
+            endedAt,
+            exitCode: exit,
+            pid,
+            stdOut,
+            stdErr,
+          });
+          if (exit == 0 || options.allowFailure) {
+            res(detailedRet);
           } else {
-            rej(
-              new Error(
-                `Command return non-zero code (${exit}) \n${cmd}\nStdOut:\n${stdOut}\nStdErr:\n${stdErr}`
-              )
-            );
+            rej(new Error(formatExecFailure(detailedRet)));
           }
 
           Neutralino.events.off("spawnedProcess", handler);
@@ -83,6 +168,123 @@ export async function exec2(
     };
     Neutralino.events.on("spawnedProcess", handler);
   });
+}
+
+export function buildExecCommand(
+  segments: CommandSegments,
+  env?: { [key: string]: string },
+  options: ExecOptions = {}
+): string {
+  const shouldRedirect = options.logFile && !options.teeOutput;
+  return build(
+    [
+      ...segments,
+      ...(shouldRedirect ? [rawString("&>"), options.logFile as string] : []),
+    ],
+    env
+  );
+}
+
+export function formatExecFailure(ret: ExecResultDetails): string {
+  return [
+    `Command return non-zero code (${ret.exitCode})`,
+    ret.phase ? `Phase: ${ret.phase}` : undefined,
+    `Command: ${ret.command}`,
+    `Cwd: ${ret.cwd}`,
+    `EnvDiff: ${ret.envDiff}`,
+    ret.logFile ? `LogFile: ${ret.logFile}` : undefined,
+    ret.pid != null ? `Pid: ${ret.pid}` : undefined,
+    `StartedAt: ${ret.startedAt}`,
+    `EndedAt: ${ret.endedAt}`,
+    `StdOut:\n${summarizeText(ret.stdOut)}`,
+    `StdErr:\n${summarizeText(ret.stdErr)}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function summarizeText(value: string): string {
+  if (value.length <= STDIO_SUMMARY_LIMIT) return value;
+  return `${value.slice(0, STDIO_SUMMARY_LIMIT)}\n...[truncated ${
+    value.length - STDIO_SUMMARY_LIMIT
+  } chars]`;
+}
+
+function normalizeExecOptions(
+  sudoOrOptions: ExecOptionsInput,
+  logRedirectOrOptions: LogRedirectInput
+): { sudo: boolean; options: ExecOptions } {
+  const sudo = typeof sudoOrOptions == "boolean" ? sudoOrOptions : false;
+  const options =
+    typeof sudoOrOptions == "object"
+      ? sudoOrOptions
+      : typeof logRedirectOrOptions == "object"
+      ? logRedirectOrOptions
+      : {};
+  if (typeof logRedirectOrOptions == "string") {
+    return {
+      sudo,
+      options: {
+        ...options,
+        logFile: logRedirectOrOptions,
+      },
+    };
+  }
+  return { sudo, options };
+}
+
+async function writeExecTrace(
+  options: ExecOptions,
+  event: {
+    status: "start" | "end";
+    command: string;
+    cwd: string;
+    envDiff: string;
+    startedAt: string;
+    endedAt?: string;
+    exitCode?: number;
+    pid?: number;
+    stdOut?: string;
+    stdErr?: string;
+  }
+) {
+  if (!options.debug && !options.teeOutput) return;
+  const lines = [
+    `=== ${options.phase ?? "command"} ${event.status} ===`,
+    `startedAt=${event.startedAt}`,
+    event.endedAt ? `endedAt=${event.endedAt}` : undefined,
+    event.pid != null ? `pid=${event.pid}` : undefined,
+    event.exitCode != null ? `exitCode=${event.exitCode}` : undefined,
+    options.logFile ? `logFile=${options.logFile}` : undefined,
+    `cwd=${event.cwd}`,
+    `command=${event.command}`,
+    `env=${event.envDiff}`,
+  ].filter(Boolean);
+  if (event.status == "end" && options.teeOutput) {
+    lines.push("stdout:");
+    lines.push(summarizeText(event.stdOut ?? ""));
+    lines.push("stderr:");
+    lines.push(summarizeText(event.stdErr ?? ""));
+  }
+  const trace = `${lines.join("\n")}\n\n`;
+  await log(trace.trimEnd());
+  if (options.logFile && (options.debug || options.teeOutput)) {
+    await appendFile(options.logFile, trace);
+  }
+}
+
+function formatEnvDiff(env?: { [key: string]: string }): string {
+  const entries = Object.entries(env ?? {}).filter(([, value]) => value);
+  if (!entries.length) return "{}";
+  return `{ ${entries.map(([key, value]) => `${key}=${value}`).join(", ")} }`;
+}
+
+function getExecutionCwd(): string {
+  try {
+    return resolve("./");
+  } catch {
+    return "unknown";
+  }
 }
 
 export function runInSudo(cmd: string) {
@@ -255,6 +457,10 @@ export async function openDir(title: string) {
 
 export async function readFile(path: string) {
   return await Neutralino.filesystem.readFile(resolve(path));
+}
+
+export async function readDirectory(path: string) {
+  return await Neutralino.filesystem.readDirectory(resolve(path));
 }
 
 export async function readBinary(path: string) {

--- a/src/wine/wine.spec.ts
+++ b/src/wine/wine.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWineEnvironmentVariables,
+  DEBUG_WINEDEBUG,
+  DEFAULT_WINEDEBUG,
+} from "./wine";
+
+describe("wine environment", () => {
+  it("enables msync for dxmt distributions", () => {
+    expect(
+      buildWineEnvironmentVariables({
+        prefix: "/tmp/prefix",
+        attributes: { renderBackend: "dxmt" },
+      })
+    ).toEqual({
+      WINEDEBUG: DEFAULT_WINEDEBUG,
+      WINEPREFIX: "/tmp/prefix",
+      WINEMSYNC: "1",
+    });
+  });
+
+  it("allows launch diagnostics to override WINEDEBUG", () => {
+    expect(
+      buildWineEnvironmentVariables({
+        prefix: "/tmp/prefix",
+        attributes: { renderBackend: "dxmt" },
+        env: { WINEDEBUG: DEBUG_WINEDEBUG },
+      }).WINEDEBUG
+    ).toBe(DEBUG_WINEDEBUG);
+  });
+
+  it("allows compatibility cleanup commands to suppress msync", () => {
+    expect(
+      buildWineEnvironmentVariables({
+        prefix: "/tmp/prefix",
+        attributes: { renderBackend: "dxmt" },
+        env: { WINEMSYNC: "" },
+      })
+    ).toEqual({
+      WINEDEBUG: DEFAULT_WINEDEBUG,
+      WINEPREFIX: "/tmp/prefix",
+      WINEMSYNC: "",
+    });
+  });
+});

--- a/src/wine/wine.ts
+++ b/src/wine/wine.ts
@@ -12,8 +12,42 @@ import {
   resolve,
   writeFile,
 } from "@utils";
+import type { ExecOptions } from "@utils";
 import { dirname, join } from "path-browserify";
 import { WineDistribution } from "./distro";
+import type { WineDistributionAttributes } from "./distro";
+
+export const DEFAULT_WINEDEBUG = "fixme-all,err-unwind,+timestamp";
+export const DEBUG_WINEDEBUG =
+  "+timestamp,+pid,+tid,+process,+module,+loaddll,+seh,+unwind";
+
+export function buildWineEnvironmentVariables({
+  prefix,
+  attributes,
+  env,
+}: {
+  prefix: string;
+  attributes: Partial<WineDistributionAttributes>;
+  env?: { [key: string]: string };
+}) {
+  const base: { [key: string]: string } = {
+    WINEDEBUG: DEFAULT_WINEDEBUG,
+    WINEPREFIX: prefix,
+    ...(attributes.renderBackend == "dxmt" ? { WINEMSYNC: "1" } : {}),
+  };
+  return {
+    ...base,
+    ...(env ?? {}),
+  };
+}
+
+function withPhase(options: ExecOptions | undefined, phase: string) {
+  return {
+    ...(options ?? {}),
+    phase,
+    allowFailure: true,
+  };
+}
 
 export async function createWine(options: {
   prefix: string;
@@ -29,16 +63,13 @@ export async function createWine(options: {
     program: string,
     args: string[],
     env?: { [key: string]: string },
-    log_file: string | undefined = undefined
+    log_file: string | ExecOptions | undefined = undefined
   ) {
     return await unixExec(
       program == "copy"
         ? [loaderBin, "cmd", "/c", program, ...args]
         : [loaderBin, program, ...args],
-      {
-        ...getEnvironmentVariables(),
-        ...(env ?? {}),
-      },
+      getEnvironmentVariables(env),
       false,
       log_file
     );
@@ -48,36 +79,66 @@ export async function createWine(options: {
     program: string,
     args: string[],
     env?: { [key: string]: string },
-    log_file: string | undefined = undefined
+    log_file: string | ExecOptions | undefined = undefined
   ) {
     return await unixExec2(
       program == "copy"
         ? [loaderBin, "cmd", "/c", program, ...args]
         : [loaderBin, program, ...args],
-      {
-        ...getEnvironmentVariables(),
-        ...(env ?? {}),
-      },
+      getEnvironmentVariables(env),
       false,
       log_file
     );
   }
 
-  async function waitUntilServerOff() {
-    return await unixExec2([join(dirname(loaderBin), "wineserver"), "-w"], {
-      ...getEnvironmentVariables(),
-    });
+  async function waitUntilServerOff(options?: ExecOptions) {
+    return await unixExec2(
+      [join(dirname(loaderBin), "wineserver"), "-w"],
+      getEnvironmentVariables(),
+      false,
+      options
+    );
+  }
+
+  async function stopServer(
+    env: { [key: string]: string },
+    options?: ExecOptions
+  ) {
+    await unixExec2(
+      [join(dirname(loaderBin), "wineserver"), "-k"],
+      env,
+      false,
+      withPhase(options, "wine.wineserver-k")
+    );
+    await unixExec2(
+      [join(dirname(loaderBin), "wineserver"), "-w"],
+      env,
+      false,
+      withPhase(options, "wine.wineserver-wait")
+    );
+  }
+
+  async function prepareForLaunch(options?: ExecOptions) {
+    await stopServer(getEnvironmentVariables(), options);
+    if (isMsyncEnabled()) {
+      await stopServer(getEnvironmentVariables({ WINEMSYNC: "" }), options);
+    }
   }
 
   function toWinePath(absPath: string) {
     return "Z:" + `${absPath}`.replaceAll("/", "\\");
   }
 
-  function getEnvironmentVariables() {
-    return {
-      WINEDEBUG: "fixme-all,err-unwind,+timestamp",
-      WINEPREFIX: options.prefix,
-    };
+  function getEnvironmentVariables(env?: { [key: string]: string }) {
+    return buildWineEnvironmentVariables({
+      prefix: options.prefix,
+      attributes: options.distro.attributes,
+      env,
+    });
+  }
+
+  function isMsyncEnabled() {
+    return options.distro.attributes.renderBackend == "dxmt";
   }
 
   async function openCmdWindow({ gameDir }: { gameDir: string }) {
@@ -93,8 +154,9 @@ export async function createWine(options: {
           "do",
           "script",
           `"${build([loaderBin, "cmd"], {
-            ...getEnvironmentVariables(),
-            WINEPATH: toWinePath(gameDir),
+            ...getEnvironmentVariables({
+              WINEPATH: toWinePath(gameDir),
+            }),
           })
             .replaceAll("\\", "\\\\")
             .replaceAll('"', '\\"')}"`,
@@ -116,7 +178,10 @@ export async function createWine(options: {
     await setKey("wine_netbiosname", netbiosname);
   }
 
-  async function setProps(props: { retina: boolean; leftCmd: boolean }) {
+  async function setProps(
+    props: { retina: boolean; leftCmd: boolean },
+    options?: { logFile?: string; debug?: boolean }
+  ) {
     const cmd = `@echo off
 cd "%~dp0"
 reg add "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver" /v RetinaMode /t REG_SZ /d ${
@@ -131,9 +196,25 @@ reg add "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver" /v LeftCommandIsCtrl /t 
       "cmd",
       ["/c", `${toWinePath(resolve("./winedrv_config.bat"))}`],
       {},
-      "/dev/null"
+      options?.debug
+        ? {
+            phase: "wine.setProps",
+            logFile: options.logFile,
+            teeOutput: true,
+            debug: true,
+          }
+        : "/dev/null"
     );
-    await waitUntilServerOff();
+    await waitUntilServerOff(
+      options?.debug
+        ? {
+            phase: "wine.setProps.wineserver-wait",
+            logFile: options.logFile,
+            teeOutput: true,
+            debug: true,
+          }
+        : undefined
+    );
   }
 
   async function setNVExtension() {
@@ -157,6 +238,7 @@ reg add "HKEY_LOCAL_MACHINE\\SOFTWARE\\NVIDIA Corporation\\Global\\NGXCore" /v F
     exec,
     exec2,
     waitUntilServerOff,
+    prepareForLaunch,
     cmd,
     toWinePath,
     prefix: options.prefix,


### PR DESCRIPTION
## Summary
- Add phase-aware command diagnostics for launcher subprocesses, including command, cwd, env diff, log file, exit code, stdout/stderr summary, and phase labels.
- Route Wine subprocess environments through one helper so DXMT launches consistently use WINEMSYNC=1, including registry helpers, winedrv_config, wineboot/winecfg, and wineserver waits.
- Add an opt-in NAP debug launch setting that writes per-phase logs for fixWebview, setProps, patching, network block, and the final game launch.
- Scan macOS DiagnosticReports and Retired reports after a launch failure so related wine-preloader, wine, Rosetta, or Yaagl crash reports are surfaced.
- Scan /etc/hosts for stale ZZZ blockNet entries and include matching hosts lines in the failure summary.
- Preserve existing patch/revert behavior and external config format; this PR does not modify game patching or validation behavior.

## Why
On macOS 27 beta, local Yaagl ZZZ logs showed the launcher reaching Wine + DXMT/MoltenVK/D3D initialization, but collapsing the final failure to code 5. The useful evidence was split across neutralinojs.log, fix_webview.log, macOS crash reports, driverError.log, and /etc/hosts.

One local crash report showed wine-preloader failing in msync_init/create_msync after mixed WINEMSYNC state in the same prefix. After fixing that, the remaining initDriver Failed [4,1114,0] was traced to a stale hosts-level ZZZ blockNet entry. Removing the stale hosts entry allowed the real ZZZ Unity window to appear with Metal HUD on macOS 27 beta.

Proxy settings are recorded in launch metadata only. They are not treated as a primary cause of this failure path.

## Verification
- pnpm exec vitest run src/utils/command-builder.spec.ts src/utils/neu.spec.ts src/utils/hosts.spec.ts src/wine/wine.spec.ts: 63 tests passed.
- pnpm exec tsc --noEmit: passed.
- pnpm run format-check: passed.
- pnpm run lint: passed with existing upstream warnings only.
- pnpm run build-dev: passed.
- Real local Yaagl ZZZ launch on macOS 27 beta generated phase logs, no new wine-preloader msync crash report appeared, and stale /etc/hosts blockNet residue was identified as the remaining driver-load cause.
- After removing the stale hosts entry, ZZZ reached a live Unity window titled 绝区零 with Metal HUD visible.

## Notes
This PR only reports stale hosts entries; it does not edit /etc/hosts automatically from the failure path.