### PR TITLE
fix macOS close crash

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -42,10 +42,19 @@ export async function createApp() {
   await setKey("singleton", null);
 
   const aria2_port = 6868;
+  let closing = false;
 
   await Neutralino.events.on("windowClose", async () => {
+    if (closing) return;
+    closing = true;
     if (await GLOBAL_onClose(false)) {
-      exit(0);
+      if (NL_OS === "Darwin") {
+        // Neutralino.app.exit() can throw NSException on macOS while the
+        // native window is already closing. See neutralinojs#1469.
+        setTimeout(() => void Neutralino.app.killProcess(), 100);
+      } else {
+        exit(0);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- avoid the macOS Neutralino close-path crash
- guard against duplicate close events

## Root cause

With `exitProcessOnClose: false`, YAAGL receives `windowClose` and then calls `Neutralino.app.exit(0)`. On macOS, this can re-enter native window teardown while the window is already closing and raise an Objective-C exception in WebKit/AppKit.

This matches [neutralinojs#1469](https://github.com/neutralinojs/neutralinojs/issues/1469).

## Fix

After cleanup, use `Neutralino.app.killProcess()` on macOS after a short delay. Other platforms retain the existing graceful `app.exit()` path. A guard prevents repeated cleanup if multiple close events arrive.

## Validation

- `./configure.sh`
- `pnpm@7.33.7 exec tsc`
- `pnpm@7.33.7 run lint` (existing warnings only)
- `pnpm@7.33.7 run format-check`
- `git diff --check`

Fixes #720
