### PR TITLE
build universal macOS app

### DIFF
--- a/build-app.js
+++ b/build-app.js
@@ -92,7 +92,9 @@ const { IconIcns } = require("@shockpkg/icon-encoder");
   }
 
   const appname = config.cli.binaryName;
-  const binaryName = `${config.cli.binaryName}-mac_x64`;
+  // Keep the app native on Apple Silicon while retaining Intel support.
+  // `neu build` produces the universal Neutralino binary for macOS.
+  const binaryName = `${config.cli.binaryName}-mac_universal`;
 
   // read package.json
   const pkg = await fs.readJSON(path.resolve(process.cwd(), "package.json"));


### PR DESCRIPTION
## Summary

- package the macOS app with Neutralino's universal binary

## Root cause

`build-app.js` always selected `*-mac_x64`, even though `neu build` generates `*-mac_universal`. As a result, Apple Silicon releases run the launcher through Rosetta and macOS displays the Intel-app support warning.

## Fix

Select `*-mac_universal` when assembling the `.app` bundle. This keeps the same release artifact compatible with both Intel and Apple Silicon Macs.

## Validation

- `./configure.sh`
- `pnpm@7.33.7 exec tsc`
- `pnpm@7.33.7 run lint` (existing warnings only)
- `pnpm@7.33.7 run format-check`
- `YAAGL_CHANNEL_CLIENT=hk4eos pnpm@7.33.7 exec vite build`
- `pnpm@7.33.7 exec neu build`
- Confirmed `dist/Yaagl/Yaagl-mac_universal` contains both x86_64 and arm64 slices.

Fixes #719
