### PR TITLE
Fix macOS restart crash

### DIFF
--- a/build-app.js
+++ b/build-app.js
@@ -223,7 +223,7 @@ mkdir -p "$APST_DIR"
 CONTENTS_DIR="$(dirname "$SCRIPT_DIR")"
 rsync -rlptu "$CONTENTS_DIR/Resources/." "$APST_DIR"
 cd "$APST_DIR"
-PATH_LAUNCH="$(dirname "$CONTENTS_DIR")" exec "$SCRIPT_DIR/${appname}" --path="$APST_DIR"`
+PATH_LAUNCH="$CONTENTS_DIR/.." exec "$SCRIPT_DIR/${appname}" --path="$APST_DIR"`
   );
 
   await fs.chmod(

--- a/src/utils/neu.ts
+++ b/src/utils/neu.ts
@@ -380,7 +380,7 @@ export async function _safeRelaunch() {
   // HACK
   if (import.meta.env.PROD) {
     const app = await Neutralino.os.getEnv("PATH_LAUNCH");
-    await Neutralino.os.execCommand(`open "${app}"`, {
+    await Neutralino.os.execCommand(`open -n "${app}"`, {
       background: true,
     });
     if (NL_OS === "Darwin") {

--- a/src/utils/neu.ts
+++ b/src/utils/neu.ts
@@ -383,8 +383,14 @@ export async function _safeRelaunch() {
     await Neutralino.os.execCommand(`open "${app}"`, {
       background: true,
     });
-    Neutralino.app.exit(0);
+    if (NL_OS === "Darwin") {
+      // Neutralino.app.exit() can throw NSException on macOS while the
+      // native window is being torn down. See neutralinojs#1469.
+      setTimeout(() => void Neutralino.app.killProcess(), 100);
+    } else {
+      Neutralino.app.exit(0);
+    }
   } else {
-    Neutralino.app.restartProcess();
+    await Neutralino.app.restartProcess();
   }
 }


### PR DESCRIPTION
## Summary
- launch a fresh replacement instance before terminating the current process
- use macOS `open -n` so the replacement is not routed to the existing instance
- use `Neutralino.app.killProcess()` on macOS instead of `Neutralino.app.exit(0)` during relaunch
- pass the actual `.app` bundle path to `open`
- retain the existing exit behavior on other platforms

## Root causes
The production relaunch path had three separate macOS issues:

1. Calling `Neutralino.app.exit(0)` while the native window was closing could throw an Objective-C exception and show the macOS “quit unexpectedly” dialog.
2. The generated `parameterized` launcher set `PATH_LAUNCH` to the directory containing the `.app`, not the `.app` itself.
3. Even with the correct bundle path, plain `open` reused the currently running app instance. The old process then exited, leaving no replacement process.

The fix uses `open -n`, `killProcess()` on macOS, and generates `PATH_LAUNCH="$CONTENTS_DIR/.."`, which resolves to the app bundle.

## Validation
- `npx --yes pnpm@7.33.7 exec tsc`
- `npx --yes pnpm@7.33.7 run lint`
- `npx --yes pnpm@7.33.7 run format-check`
- packaged and launched a local ZZZ test app
- reset the test app Wine state to exercise initial configuration

Fixes #724