### PR TITLE
fix(sophon): 校验 manifest 缓存并使用原子下载

### DIFF
--- a/sophon_server/cache.py
+++ b/sophon_server/cache.py
@@ -1,0 +1,70 @@
+import hashlib
+import os
+import shutil
+import time
+import uuid
+import urllib.request as request
+
+
+CACHE_MAX_AGE = 24 * 3600
+
+
+def validate_cached_file(path, expected_size=None, expected_md5=None):
+	if not path.is_file():
+		return False
+
+	if expected_size is not None and path.stat().st_size != expected_size:
+		return False
+
+	if expected_md5 is not None:
+		digest = hashlib.md5()
+		with path.open("rb") as fh:
+			for block in iter(lambda: fh.read(1024 * 1024), b""):
+				digest.update(block)
+		if digest.hexdigest().lower() != expected_md5.lower():
+			return False
+
+	return True
+
+
+def load_cached_file(path, url, post_data=None, expected_size=None,
+	                 expected_md5=None, force_use_cache=False,
+	                 reuse_valid_cache=False):
+	cache_valid = validate_cached_file(path, expected_size, expected_md5)
+
+	if force_use_cache:
+		if not cache_valid:
+			raise IOError(f"Cached file is missing or invalid: {path}")
+		return False
+
+	if cache_valid:
+		# Checksummed files are content-validated and do not expire by age.
+		if expected_md5 is not None or reuse_valid_cache:
+			return False
+		if time.time() - path.stat().st_mtime <= CACHE_MAX_AGE:
+			return False
+
+	if callable(url):
+		url = url()
+
+	partial = path.with_name(f".{path.name}.{uuid.uuid4().hex}.part")
+	try:
+		if post_data is not None:
+			req = request.Request(url, data=post_data)
+			with request.urlopen(req) as resp, partial.open("wb") as fh:
+				shutil.copyfileobj(resp, fh)
+		else:
+			request.urlretrieve(url, partial)
+
+		if not validate_cached_file(partial, expected_size, expected_md5):
+			actual_size = partial.stat().st_size if partial.is_file() else None
+			raise IOError(
+				f"Downloaded file validation failed: {path.name}; "
+				f"expected_size={expected_size}, actual_size={actual_size}, "
+				f"expected_md5={expected_md5}"
+			)
+
+		os.replace(partial, path)
+		return True
+	finally:
+		partial.unlink(missing_ok=True)

--- a/sophon_server/manifest_cache.py
+++ b/sophon_server/manifest_cache.py
@@ -1,0 +1,67 @@
+import hashlib
+
+import zstandard
+from google.protobuf.message import DecodeError
+
+
+class ManifestDecodeError(IOError):
+	pass
+
+
+def decode_manifest(path, compression, expected_size, manifest_type,
+	                expected_md5=None):
+	with path.open("rb") as manifest_file:
+		if compression == 0:
+			manifest_bytes = manifest_file.read()
+		elif compression == 1:
+			with zstandard.ZstdDecompressor().stream_reader(manifest_file) as reader:
+				manifest_bytes = reader.read()
+		else:
+			raise ValueError(f"Unsupported manifest compression type: {compression}")
+
+	if len(manifest_bytes) != expected_size:
+		raise ManifestDecodeError(
+			"Decompressed manifest size mismatch: "
+			f"expected {expected_size}, got {len(manifest_bytes)}"
+		)
+
+	if expected_md5 is not None:
+		actual_md5 = hashlib.md5(manifest_bytes).hexdigest()
+		if actual_md5.lower() != expected_md5.lower():
+			raise ManifestDecodeError(
+				"Decompressed manifest checksum mismatch: "
+				f"expected {expected_md5}, got {actual_md5}"
+			)
+
+	manifest = manifest_type()
+	manifest.ParseFromString(manifest_bytes)
+	return manifest
+
+
+def load_manifest_with_retry(load_path, cached_path, compression, expected_size,
+	                         manifest_type, force_use_cache, warn,
+	                         expected_md5=None):
+	for attempt in range(2):
+		try:
+			manifest_path = load_path()
+		except IOError:
+			if attempt == 1 or force_use_cache:
+				raise
+			warn("Manifest download failed; retrying.")
+			continue
+
+		try:
+			return decode_manifest(
+				manifest_path, compression, expected_size, manifest_type,
+				expected_md5,
+			)
+		except (ManifestDecodeError, zstandard.ZstdError, DecodeError):
+			if force_use_cache:
+				raise
+
+			cached_path.unlink(missing_ok=True)
+			if attempt == 1:
+				raise
+			warn("Manifest cache is invalid; downloading it again.")
+
+	raise AssertionError("Manifest retry loop exited unexpectedly")

--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -62,7 +62,6 @@ import sys # stdout
 import tempfile # patch extraction
 import time
 from typing import Literal, Optional
-import uuid
 import struct
 import urllib.error # exception handling
 import urllib.request as request # downloads
@@ -71,6 +70,9 @@ from typing import TYPE_CHECKING
 import psutil
 import zstandard # archive unpacking
 from google.protobuf.json_format import MessageToJson
+
+from cache import load_cached_file
+from manifest_cache import load_manifest_with_retry
 
 import manifest_pb2 # generated
 import manifest_ldiff_pb2 # generated
@@ -571,36 +573,21 @@ class SophonClient:
 		shutil.rmtree(OPT.tempdir)
 
 
-	def load_cached_api_file(self, fname, url, POST_data = None):
+	def load_cached_api_file(self, fname, url, POST_data = None,
+	                         expected_size = None, expected_md5 = None,
+	                         reuse_valid_cache = False):
 		"""
-		Cached file download. For JSON (API) files only!
+		Download and cache an API response or manifest file.
 
-		fname: file name without path prefix
-		url:   str or function ptr to retrieve the URL
-		Returns: File handle
+		Files are downloaded atomically. Optional size and MD5 values are
+		used to validate both cached and newly downloaded files.
 		"""
 		fullname = tempdir(fname)
-		do_download = True
-
-		if fullname.is_file():
-			# keep cached for 24 hours
-			do_download = time.time() - fullname.stat().st_mtime > (24 * 3600)
-
-		if OPT.force_use_cache:
-			do_download = False
-
-		if do_download:
-			# Check whether the file is still up-to-date
-			if callable(url):
-				url = url()
-
-			if POST_data != None:
-				req = request.Request(url, data=POST_data)
-				resp = request.urlopen(req)
-				with fullname.open("wb") as fh:
-					fh.write(resp.read())
-			else:
-				request.urlretrieve(url, fullname)
+		downloaded = load_cached_file(
+			fullname, url, POST_data, expected_size, expected_md5,
+			OPT.force_use_cache, reuse_valid_cache,
+		)
+		if downloaded:
 			debuglog(f"Downloaded new file '{fname}'") #, src={url}")
 		else:
 			debuglog(f"Loaded existing file '{fname}'")
@@ -776,20 +763,36 @@ class SophonClient:
 		dlinfo.category_json = category
 
 		# Download and decompress manifest protobuf
-		fname_raw = category["manifest"]["id"]
-		url = category["manifest_download"]["url_prefix"] + "/" + category["manifest"]["id"]
+		manifest_info = category["manifest"]
+		fname_raw = manifest_info["id"]
+		url = category["manifest_download"]["url_prefix"] + "/" + fname_raw
+		compressed_size = int(manifest_info["compressed_size"])
+		expected_md5 = manifest_info["checksum"]
+		expected_uncompressed_size = int(manifest_info["uncompressed_size"])
+		compression = int(category["manifest_download"].get("compression", 0))
 
-		zstd_path = self.load_cached_api_file(fname_raw + ".zstd", url)
-		with zstd_path.open('br') as zfh:
-			reader = zstandard.ZstdDecompressor().stream_reader(zfh)
-			pb = None
-			if dlinfo == self.di_diffs:
-				pb = manifest_ldiff_pb2.DiffManifest()
-			elif dlinfo == self.di_chunks:
-				pb = manifest_pb2.Manifest()
-			else:
-				assert False, "unknown instance"
-			pb.ParseFromString(reader.read())
+		if dlinfo == self.di_diffs:
+			manifest_type = manifest_ldiff_pb2.DiffManifest
+		elif dlinfo == self.di_chunks:
+			manifest_type = manifest_pb2.Manifest
+		else:
+			assert False, "unknown instance"
+
+		manifest_path = tempdir(fname_raw + ".zstd")
+		pb = load_manifest_with_retry(
+			lambda: self.load_cached_api_file(
+					fname_raw + ".zstd", url,
+					expected_size=compressed_size,
+					reuse_valid_cache=True,
+				),
+			manifest_path,
+			compression,
+			expected_uncompressed_size,
+			manifest_type,
+			OPT.force_use_cache,
+			lambda message: warnlog(dlinfo.name, message),
+			expected_md5=expected_md5,
+		)
 		nfiles = len(pb.files)
 		debuglog(dlinfo.name, f"Decompressed manifest protobuf ({nfiles} files)")
 

--- a/sophon_server/test_cache.py
+++ b/sophon_server/test_cache.py
@@ -1,0 +1,133 @@
+import hashlib
+import os
+import pathlib
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+from cache import CACHE_MAX_AGE, load_cached_file
+
+
+class CachedFileTest(unittest.TestCase):
+	def setUp(self):
+		self.temp_dir = tempfile.TemporaryDirectory()
+		self.path = pathlib.Path(self.temp_dir.name) / "manifest.zstd"
+
+	def tearDown(self):
+		self.temp_dir.cleanup()
+
+	@staticmethod
+	def md5(data):
+		return hashlib.md5(data).hexdigest()
+
+	def test_interrupted_ttl_refresh_does_not_replace_valid_cache(self):
+		cached = b"valid cache"
+		self.path.write_bytes(cached)
+		old = time.time() - CACHE_MAX_AGE - 1
+		os.utime(self.path, (old, old))
+
+		def interrupt(_url, partial):
+			pathlib.Path(partial).write_bytes(b"partial")
+			raise OSError("connection interrupted")
+
+		with mock.patch("cache.request.urlretrieve", side_effect=interrupt):
+			with self.assertRaisesRegex(OSError, "connection interrupted"):
+				load_cached_file(
+					self.path,
+					"https://example.invalid/manifest",
+					expected_size=len(cached),
+				)
+
+		self.assertEqual(self.path.read_bytes(), cached)
+		self.assertEqual(list(self.path.parent.glob("*.part")), [])
+
+	def test_stale_validated_cache_is_reused_without_download(self):
+		cached = b"valid cache"
+		self.path.write_bytes(cached)
+		old = time.time() - CACHE_MAX_AGE - 1
+		os.utime(self.path, (old, old))
+
+		with mock.patch("cache.request.urlretrieve") as retrieve:
+			was_downloaded = load_cached_file(
+				self.path,
+				"https://example.invalid/manifest",
+				expected_size=len(cached),
+				expected_md5=self.md5(cached),
+			)
+
+		self.assertFalse(was_downloaded)
+		retrieve.assert_not_called()
+
+	def test_stale_size_validated_cache_can_be_reused_by_caller(self):
+		cached = b"compressed manifest"
+		self.path.write_bytes(cached)
+		old = time.time() - CACHE_MAX_AGE - 1
+		os.utime(self.path, (old, old))
+
+		with mock.patch("cache.request.urlretrieve") as retrieve:
+			was_downloaded = load_cached_file(
+				self.path,
+				"https://example.invalid/manifest",
+				expected_size=len(cached),
+				reuse_valid_cache=True,
+			)
+
+		self.assertFalse(was_downloaded)
+		retrieve.assert_not_called()
+
+	def test_fresh_truncated_cache_is_redownloaded(self):
+		downloaded = b"complete manifest"
+		self.path.write_bytes(downloaded[:5])
+
+		def download(_url, partial):
+			pathlib.Path(partial).write_bytes(downloaded)
+
+		with mock.patch("cache.request.urlretrieve", side_effect=download) as retrieve:
+			was_downloaded = load_cached_file(
+				self.path,
+				"https://example.invalid/manifest",
+				expected_size=len(downloaded),
+				expected_md5=self.md5(downloaded),
+			)
+
+		self.assertTrue(was_downloaded)
+		retrieve.assert_called_once()
+		self.assertEqual(self.path.read_bytes(), downloaded)
+
+	def test_same_size_wrong_checksum_is_redownloaded(self):
+		downloaded = b"right bytes"
+		self.path.write_bytes(b"wrong bytes")
+
+		def download(_url, partial):
+			pathlib.Path(partial).write_bytes(downloaded)
+
+		with mock.patch("cache.request.urlretrieve", side_effect=download) as retrieve:
+			load_cached_file(
+				self.path,
+				"https://example.invalid/manifest",
+				expected_size=len(downloaded),
+				expected_md5=self.md5(downloaded),
+			)
+
+		retrieve.assert_called_once()
+		self.assertEqual(self.path.read_bytes(), downloaded)
+
+	def test_force_cache_failure_does_not_delete_cache(self):
+		cached = b"invalid"
+		self.path.write_bytes(cached)
+
+		with self.assertRaisesRegex(IOError, "missing or invalid"):
+			load_cached_file(
+				self.path,
+				"https://example.invalid/manifest",
+				expected_size=100,
+				expected_md5="0" * 32,
+				force_use_cache=True,
+			)
+
+		self.assertEqual(self.path.read_bytes(), cached)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/sophon_server/test_manifest_cache.py
+++ b/sophon_server/test_manifest_cache.py
@@ -1,0 +1,124 @@
+import hashlib
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+import zstandard
+
+from cache import load_cached_file
+from manifest_cache import decode_manifest, load_manifest_with_retry
+
+
+class FakeManifest:
+	def ParseFromString(self, data):
+		self.data = data
+
+
+class ManifestCacheTest(unittest.TestCase):
+	def setUp(self):
+		self.temp_dir = tempfile.TemporaryDirectory()
+		self.path = pathlib.Path(self.temp_dir.name) / "manifest"
+
+	def tearDown(self):
+		self.temp_dir.cleanup()
+
+	def test_download_failure_preserves_existing_manifest(self):
+		cached = b"old manifest"
+		expected = b"new manifest"
+		self.path.write_bytes(cached)
+
+		def interrupt(_url, partial):
+			pathlib.Path(partial).write_bytes(b"partial")
+			raise OSError("connection interrupted")
+
+		def load_path():
+			load_cached_file(
+				self.path,
+				"https://example.invalid/manifest",
+				expected_size=len(expected),
+				expected_md5=hashlib.md5(expected).hexdigest(),
+			)
+			return self.path
+
+		with mock.patch("cache.request.urlretrieve", side_effect=interrupt):
+			with self.assertRaisesRegex(OSError, "connection interrupted"):
+				load_manifest_with_retry(
+					load_path, self.path, 0, len(expected), FakeManifest,
+					False, lambda _message: None,
+				)
+
+		self.assertEqual(self.path.read_bytes(), cached)
+
+	def test_force_cache_decode_failure_does_not_delete_cache(self):
+		cached = b"invalid"
+		self.path.write_bytes(cached)
+
+		with self.assertRaisesRegex(IOError, "size mismatch"):
+			load_manifest_with_retry(
+				lambda: self.path, self.path, 0, 100, FakeManifest,
+				True, lambda _message: None,
+			)
+
+		self.assertEqual(self.path.read_bytes(), cached)
+
+	def test_decode_failure_deletes_cache_and_retries(self):
+		valid = b"valid"
+		self.path.write_bytes(b"bad")
+		load_count = 0
+
+		def load_path():
+			nonlocal load_count
+			load_count += 1
+			if load_count == 2:
+				self.path.write_bytes(valid)
+			return self.path
+
+		manifest = load_manifest_with_retry(
+			load_path, self.path, 0, len(valid), FakeManifest,
+			False, lambda _message: None,
+		)
+
+		self.assertEqual(load_count, 2)
+		self.assertEqual(manifest.data, valid)
+
+	def test_decode_zstd_manifest(self):
+		manifest_bytes = b"manifest protobuf bytes"
+		compressed = zstandard.ZstdCompressor().compress(manifest_bytes)
+		self.path.write_bytes(compressed)
+
+		manifest = decode_manifest(
+			self.path, 1, len(manifest_bytes), FakeManifest,
+			expected_md5=hashlib.md5(manifest_bytes).hexdigest(),
+		)
+
+		self.assertNotEqual(
+			hashlib.md5(compressed).hexdigest(),
+			hashlib.md5(manifest_bytes).hexdigest(),
+		)
+		self.assertEqual(manifest.data, manifest_bytes)
+
+	def test_decompressed_checksum_failure_deletes_cache_and_retries(self):
+		valid = b"valid manifest"
+		self.path.write_bytes(zstandard.ZstdCompressor().compress(b"wrong manifest"))
+		load_count = 0
+
+		def load_path():
+			nonlocal load_count
+			load_count += 1
+			if load_count == 2:
+				self.path.write_bytes(zstandard.ZstdCompressor().compress(valid))
+			return self.path
+
+		manifest = load_manifest_with_retry(
+			load_path, self.path, 1, len(valid), FakeManifest,
+			False, lambda _message: None,
+			expected_md5=hashlib.md5(valid).hexdigest(),
+		)
+
+		self.assertEqual(load_count, 2)
+		self.assertEqual(manifest.data, valid)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/src/clients/mhy/hk4e/index.tsx
+++ b/src/clients/mhy/hk4e/index.tsx
@@ -95,6 +95,9 @@ export async function createHK4EChannelClient({
 
   const gameInfo = await sophon.getLatestOnlineGameInfo(releaseType, "hk4e");
   log(`Game info: ${JSON.stringify(gameInfo)}`);
+  if (gameInfo.error || !gameInfo.version) {
+    throw new Error(gameInfo.error || "Failed to retrieve online game version");
+  }
   const LATEST_GAME_VERSION: string = gameInfo.version;
   const UPDATABLE_VERSIONS: string[] = gameInfo.updatable_versions;
   const PRE_DOWNLOAD_VERSION: string = gameInfo.pre_download_version || "0.0.0";


### PR DESCRIPTION
## 问题

Sophon manifest 下载会直接写入最终缓存路径。如果连接在下载途中中断，截断文件仍可能留在缓存中；而现有逻辑只根据 24 小时 mtime 判断是否复用，不校验服务端已经提供的压缩前后大小和 checksum。

后续启动会持续读取同一个截断的 Zstd frame，protobuf 解析失败后返回空版本，前端再把空字符串传给 `semver.lt()`，最终显示 `TypeError: Invalid Version`。

## 修改

- 下载到同目录的唯一 `.part` 文件，校验成功后通过 `os.replace()` 原子替换正式缓存；异常路径会清理临时文件并保留原缓存。
- 根据 `getBuild` 中的 `compressed_size` 校验压缩缓存，阻止截断文件进入或继续留在正式缓存路径。
- Zstd 解压后校验 `uncompressed_size`，并对解压后的 manifest protobuf 字节计算 MD5，与 `manifest.checksum` 比较。
- checksum 属于解压后的 manifest 内容，不用于校验压缩文件。线上样本中压缩文件 MD5 与 `manifest.checksum` 不同，但解压内容 MD5 与 checksum 完全一致。
- 通过压缩大小及解压后 checksum 验证的 manifest 按内容复用，不受 24 小时 mtime 限制。当前 `getBuild` 引用相同内容身份时无需重新下载；内容不符时会删除损坏缓存并重试。
- 没有内容身份元数据的 JSON API 缓存继续使用 TTL。
- 根据 `manifest_download.compression` 选择原始读取或 Zstd 解压。
- manifest 下载失败时保留现有正式缓存并重试；只有正式缓存解压、长度、checksum 或 protobuf 解析失败时才删除损坏文件并重新下载。
- `force_use_cache` 模式下，下载校验或解码失败均不会删除、替换缓存文件。
- 在线版本接口返回错误或空版本时，在调用 semver 前抛出后端错误，避免 UI 再次以 `Invalid Version` 崩溃。

## 验证

- `uv run python -m unittest -v test_cache.py test_manifest_cache.py`（11 个测试）
  - 中断下载不会覆盖原缓存，且 `.part` 文件会被清理
  - 新鲜但截断的缓存会重新下载
  - 通用缓存 helper 会拒绝等长但 MD5 错误的文件
  - helper 与 manifest 层的强制缓存失败均不会删除缓存
  - 下载失败时外层重试仍保留现有正式文件
  - 解码、解压后长度或 checksum 损坏会删除缓存并重试
  - Zstd manifest 正常解压路径
  - 超过 24 小时的 manifest 缓存可交由解码层继续做内容校验
- 使用线上 8,158,155 字节 Zstd manifest 做集成验证：
  - 解压大小为 15,253,763 字节
  - 解压内容 MD5 与 `manifest.checksum` 一致
  - protobuf 成功解析出 2,579 个文件条目
- `uv run python -m py_compile cache.py manifest_cache.py sophon_api.py test_cache.py test_manifest_cache.py`
- `pnpm exec eslint src/clients/mhy/hk4e/index.tsx`
- `pnpm exec prettier -c src/clients/mhy/hk4e/index.tsx`
- `git diff --check`

完整 `pnpm run precommit` 的 TypeScript 阶段仍需要先由项目配置流程生成未纳入仓库的 `src/clients/secret.ts`；本次变更文件的 ESLint 与 Prettier 检查已单独通过。

Closes #699

可能关联 #726
